### PR TITLE
Change sysdig_secure_images to analyze their own image

### DIFF
--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -13,6 +13,7 @@ node {
             sh '''
                 sudo docker login --username ${DOCKER_USERNAME} --password ${DOCKER_PASSWORD}
                 sudo docker push ${DOCKER_REPOSITORY}
+                echo docker.io/${DOCKER_REPOSITORY} > sysdig_secure_images
             '''
         }
     }


### PR DESCRIPTION
The file named sysdig_secure_images must be overwritten with the correct image name so Anchore can analyze it.